### PR TITLE
Patch bug in log_hooks.lua

### DIFF
--- a/assets/policy-extras/log_hooks.lua
+++ b/assets/policy-extras/log_hooks.lua
@@ -214,11 +214,12 @@ function mod:new_json(options)
       -- it reached it expiration.
       kumo.reject(500, disposition)
     end
-    return connection
-  end
 
-  function connection:close()
-    client:close()
+    function connection:close()
+      client:close()
+    end
+    
+    return connection
   end
 
   return self:new(options)


### PR DESCRIPTION
I believe connection:close was inserted in the wrong place and should be inside the constructor function with the connection object.

Using kumod 2024.07.24-84bc2f05  calling log_hooks:new_json causes a crash if used.